### PR TITLE
Enable real-time speech transcription

### DIFF
--- a/realtime.js
+++ b/realtime.js
@@ -13,8 +13,9 @@ if (!OPENAI_KEY) {
   process.exit(1);
 }
 
-// URL to OpenAI Realtime - change params per latest docs (model/intent).
-const OPENAI_WS_URL = 'wss://api.openai.com/v1/realtime?intent=transcription';
+// URL to OpenAI Realtime. Specify a transcription model and enable the realtime beta.
+const OPENAI_WS_URL =
+  'wss://api.openai.com/v1/realtime?model=gpt-4o-mini-transcribe';
 
 const server = http.createServer((req, res) => {
   // simple diagnostic endpoint
@@ -36,7 +37,7 @@ wss.on('connection', (clientWs, req) => {
   const openaiWs = new WebSocket(OPENAI_WS_URL, {
     headers: {
       Authorization: `Bearer ${OPENAI_KEY}`,
-      // Add any headers required by OpenAI docs; e.g. 'OpenAI-Beta': 'realtime=v1' if required
+      'OpenAI-Beta': 'realtime=v1',
     },
   });
 
@@ -69,11 +70,8 @@ wss.on('connection', (clientWs, req) => {
       return;
     }
 
-    // If client sent binary (Buffer) — forward as binary
+    // If a binary frame somehow arrives, forward it unchanged
     if (Buffer.isBuffer(msg) || msg instanceof ArrayBuffer) {
-      // If OpenAI expects base64 in JSON, encode; else forward raw binary.
-      // Many realtime implementations accept either raw opus frames or base64 JSON messages.
-      // We'll *forward binary raw* to OpenAI; if OpenAI expects base64, adjust here.
       openaiWs.send(msg);
       return;
     }


### PR DESCRIPTION
## Summary
- connect proxy to OpenAI `gpt-4o-mini-transcribe` realtime endpoint and enable realtime beta header
- send microphone chunks as base64 `input_audio_buffer.append` events and request transcription on first chunk
- flush and commit audio buffer on stop for final transcripts

## Testing
- `node --version`
- `node --check realtime.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68bbfadfcd648328bf3a982dd181daa0