### PR TITLE
Revamp AI watchlist filter UI with Tailwind styling

### DIFF
--- a/watchlist.vue
+++ b/watchlist.vue
@@ -1,206 +1,268 @@
 <template>
-  <div class="ai-filter-wrapper" :class="{ 'dark-mode': isDarkMode }">
-    <!-- AI Filter Trigger Button -->
-    <button 
+  <div
+    class="relative inline-flex"
+    :class="isDarkMode ? 'text-slate-100' : 'text-slate-900'"
+  >
+    <button
       @click="openAIFilter"
-      class="ai-filter-trigger"
-      :class="{ 'active': isAIFilterOpen }"
+      class="group inline-flex items-center gap-2 rounded-full px-5 py-3 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+      :class="[
+        isDarkMode
+          ? 'bg-gradient-to-r from-indigo-500 via-purple-500 to-sky-500 text-white shadow-lg shadow-indigo-500/30 focus-visible:ring-indigo-300 focus-visible:ring-offset-slate-950'
+          : 'bg-gradient-to-r from-indigo-500 via-purple-500 to-sky-500 text-white shadow-lg shadow-indigo-500/30 focus-visible:ring-indigo-600 focus-visible:ring-offset-white',
+        isAIFilterOpen ? 'ring-2 ring-offset-2 ring-indigo-400' : 'hover:shadow-xl hover:shadow-indigo-500/40'
+      ]"
     >
-      <Sparkles class="ai-icon" />
+      <Sparkles class="h-5 w-5 transition-transform duration-200 group-hover:scale-110" />
       <span>AI Filter</span>
     </button>
 
-    <!-- AI Filter Modal -->
-    <UModal 
+    <UModal
       v-model="isAIFilterOpen"
-      :ui="{ 
-        base: 'relative text-left rtl:text-right overflow-hidden !w-screen !h-screen !max-w-none !m-0 flex flex-col', 
-        background: isDarkMode ? 'bg-gray-900' : 'bg-white', 
-        rounded: '!rounded-none', 
+      :ui="{
+        base: 'relative text-left overflow-hidden !w-screen !h-screen !max-w-none !m-0 flex flex-col',
+        background: isDarkMode ? 'bg-slate-950' : 'bg-slate-50',
+        rounded: '!rounded-none',
         shadow: 'shadow-none',
         padding: '!p-0'
       }"
     >
-      <div class="ai-modal-container">
-        <!-- Header -->
-        <div class="ai-modal-header">
-          <div class="header-content">
-            <div class="header-icon-wrapper">
-              <Sparkles class="header-icon" />
+      <div class="flex h-full flex-col" :class="isDarkMode ? 'bg-slate-950 text-slate-100' : 'bg-slate-50 text-slate-900'">
+        <div
+          class="flex items-start justify-between gap-6 border-b px-10 py-8"
+          :class="isDarkMode ? 'border-slate-800/80 bg-slate-950/80' : 'border-slate-200 bg-white/70'"
+        >
+          <div class="flex items-start gap-4">
+            <div
+              class="flex h-12 w-12 items-center justify-center rounded-2xl"
+              :class="isDarkMode ? 'bg-indigo-500/20 text-indigo-300 ring-1 ring-inset ring-indigo-500/40' : 'bg-indigo-100 text-indigo-600 ring-1 ring-inset ring-indigo-200'"
+            >
+              <Sparkles class="h-6 w-6" />
             </div>
             <div>
-              <h3 class="ai-modal-title">AI Watchlist Filter</h3>
-              <p class="ai-modal-subtitle">Tell me what you're in the mood for</p>
+              <h3 class="text-2xl font-semibold tracking-tight">Tune your watchlist with AI</h3>
+              <p class="mt-1 text-sm leading-relaxed" :class="isDarkMode ? 'text-slate-300' : 'text-slate-600'">
+                Describe the mood, pace or themes you're craving. We'll surface the perfect matches from your saved titles and suggest a few fresh finds.
+              </p>
             </div>
           </div>
-          <button @click="closeAIFilter" class="close-btn">
-            <XIcon class="close-icon" />
+          <button
+            @click="closeAIFilter"
+            class="flex h-11 w-11 items-center justify-center rounded-xl border text-sm font-medium transition hover:scale-105 focus:outline-none focus-visible:ring-2"
+            :class="isDarkMode ? 'border-slate-800 bg-slate-900/70 text-slate-300 hover:border-indigo-500 hover:text-white focus-visible:ring-indigo-400' : 'border-slate-200 bg-white text-slate-500 hover:border-indigo-300 hover:text-indigo-500 focus-visible:ring-indigo-500'"
+          >
+            <span class="sr-only">Close</span>
+            <XIcon class="h-5 w-5" />
           </button>
         </div>
 
-        <!-- Body -->
-        <div class="ai-modal-body">
-          <!-- Input Section -->
-          <div class="input-section">
-            <div class="input-wrapper">
-              <textarea
-                v-model="userQuery"
-                @keydown.enter.ctrl="submitQuery"
-                placeholder="E.g., 'romantic and funny movies', 'something intense and thrilling', 'light-hearted comedies for a lazy Sunday'..."
-                class="ai-input"
-                rows="3"
-                :disabled="isLoading"
-              ></textarea>
-              <div class="input-footer">
-                <span class="input-hint">Press Ctrl+Enter to submit</span>
-                <span class="char-count">{{ userQuery.length }}/500</span>
-              </div>
-            </div>
-
-            <!-- Quick Suggestions -->
-            <div class="quick-suggestions">
-              <span class="suggestions-label">Quick ideas:</span>
-              <button 
-                v-for="suggestion in quickSuggestions" 
-                :key="suggestion"
-                @click="userQuery = suggestion"
-                class="suggestion-chip"
-                :disabled="isLoading"
-              >
-                {{ suggestion }}
-              </button>
-            </div>
-
-            <!-- Submit Button -->
-            <button 
-              @click="submitQuery"
-              :disabled="!userQuery.trim() || isLoading"
-              class="submit-btn"
+        <div class="flex-1 overflow-y-auto px-10 py-8">
+          <div class="mx-auto flex w-full max-w-5xl flex-col gap-10">
+            <section
+              class="relative overflow-hidden rounded-3xl border px-8 py-8 shadow-lg transition"
+              :class="isDarkMode ? 'border-slate-800/80 bg-slate-900/70 shadow-black/40' : 'border-slate-200 bg-white shadow-slate-200/60'"
             >
-              <Loader2 v-if="isLoading" class="loading-icon" />
-              <Sparkles v-else class="submit-icon" />
-              {{ isLoading ? 'Finding matches...' : 'Find Matches' }}
-            </button>
-          </div>
+              <div class="absolute inset-y-0 right-0 hidden w-72 bg-gradient-to-l from-indigo-500/10 to-transparent md:block" />
+              <header class="flex flex-col gap-2 pb-6">
+                <h4 class="text-lg font-semibold">Share what you're in the mood for</h4>
+                <p class="text-sm" :class="isDarkMode ? 'text-slate-300' : 'text-slate-600'">
+                  Use natural language&mdash;anything from "slow-burn mysteries" to "optimistic sci-fi for family night". We'll do the rest.
+                </p>
+              </header>
 
-          <!-- Loading State -->
-          <div v-if="isLoading" class="loading-state">
-            <div class="loading-animation">
-              <div class="loading-circle"></div>
-              <div class="loading-circle"></div>
-              <div class="loading-circle"></div>
-            </div>
-            <p class="loading-text">Analyzing your watchlist with AI...</p>
-          </div>
-
-          <!-- Results Section -->
-          <div v-if="!isLoading && hasResults" class="results-section">
-            <!-- Query Display -->
-            <div class="query-display">
-              <Brain class="query-icon" />
-              <p class="query-text">"{{ originalQuery }}"</p>
-            </div>
-
-            <!-- Filtered Bookmarks -->
-            <div v-if="filteredBookmarks.length > 0" class="results-group">
-              <div class="results-header">
-                <h4 class="results-title">
-                  <Film class="section-icon" />
-                  From Your Watchlist
-                </h4>
-                <span class="results-count">{{ filteredBookmarks.length }} matches</span>
-              </div>
-              <div class="movies-grid">
-                <div 
-                  v-for="movie in filteredBookmarks" 
-                  :key="movie.id"
-                  class="movie-card"
-                  @click="navigateToMovie(movie)"
-                >
-                  <div class="movie-poster-wrapper">
-                    <img 
-                      v-if="movie.poster_path"
-                      :src="`https://image.tmdb.org/t/p/w500${movie.poster_path}`"
-                      :alt="movie.title"
-                      class="movie-poster"
-                    />
-                    <div v-else class="poster-placeholder">
-                      <Film class="placeholder-icon" />
-                    </div>
-                    <div class="movie-overlay">
-                      <Play class="play-icon" />
-                    </div>
+              <div class="flex flex-col gap-6">
+                <div class="space-y-3">
+                  <textarea
+                    v-model="userQuery"
+                    @keydown.enter.ctrl="submitQuery"
+                    rows="3"
+                    :disabled="isLoading"
+                    placeholder="e.g. 'romantic and funny movies' or 'smart thrillers with a twist'"
+                    class="w-full resize-none rounded-2xl border px-4 py-4 text-base shadow-sm transition focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                    :class="[
+                      isDarkMode
+                        ? 'border-slate-700 bg-slate-900/70 text-slate-100 placeholder:text-slate-500'
+                        : 'border-slate-200 bg-slate-50 text-slate-900 placeholder:text-slate-400',
+                      isLoading ? 'opacity-70' : 'hover:border-indigo-400'
+                    ]"
+                  ></textarea>
+                  <div class="flex flex-wrap items-center justify-between gap-3 text-xs" :class="isDarkMode ? 'text-slate-400' : 'text-slate-500'">
+                    <span>Press <kbd class="rounded-md border px-1.5 py-0.5" :class="isDarkMode ? 'border-slate-700 bg-slate-900 text-slate-300' : 'border-slate-200 bg-white text-slate-600'">Ctrl</kbd> + <kbd class="rounded-md border px-1.5 py-0.5" :class="isDarkMode ? 'border-slate-700 bg-slate-900 text-slate-300' : 'border-slate-200 bg-white text-slate-600'">Enter</kbd> to submit</span>
+                    <span>{{ userQuery.length }}/500</span>
                   </div>
-                  <div class="movie-info">
-                    <h5 class="movie-title">{{ movie.title }}</h5>
-                    <p class="movie-year">{{ movie.year }}</p>
-                    <p v-if="movie.match_reason" class="movie-reason">{{ movie.match_reason }}</p>
+                </div>
+
+                <div class="flex flex-wrap gap-2">
+                  <span class="text-xs font-semibold uppercase tracking-wide" :class="isDarkMode ? 'text-slate-400' : 'text-slate-500'">Try one:</span>
+                  <div class="flex flex-wrap gap-2">
+                    <button
+                      v-for="suggestion in quickSuggestions"
+                      :key="suggestion"
+                      @click="userQuery = suggestion"
+                      :disabled="isLoading"
+                      class="rounded-full px-4 py-1.5 text-sm font-medium transition focus:outline-none focus-visible:ring-2"
+                      :class="isDarkMode ? 'bg-slate-800 text-slate-200 hover:bg-slate-700 focus-visible:ring-indigo-400' : 'bg-slate-100 text-slate-600 hover:bg-slate-200 focus-visible:ring-indigo-500'"
+                    >
+                      {{ suggestion }}
+                    </button>
+                  </div>
+                </div>
+
+                <div class="flex justify-end">
+                  <button
+                    @click="submitQuery"
+                    :disabled="!userQuery.trim() || isLoading"
+                    class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-indigo-500 via-purple-500 to-sky-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 disabled:cursor-not-allowed disabled:opacity-70"
+                  >
+                    <Loader2 v-if="isLoading" class="h-5 w-5 animate-spin" />
+                    <Sparkles v-else class="h-5 w-5" />
+                    {{ isLoading ? 'Finding matches...' : 'Find Matches' }}
+                  </button>
+                </div>
+              </div>
+            </section>
+
+            <div v-if="isLoading" class="flex flex-col items-center gap-4 rounded-3xl border px-8 py-12 text-center shadow-lg" :class="isDarkMode ? 'border-slate-800/80 bg-slate-900/60 shadow-black/30' : 'border-slate-200 bg-white shadow-slate-200/60'">
+              <div class="flex gap-2">
+                <span class="h-3 w-3 animate-bounce rounded-full" :class="isDarkMode ? 'bg-indigo-400' : 'bg-indigo-500'" style="animation-delay: 0s"></span>
+                <span class="h-3 w-3 animate-bounce rounded-full" :class="isDarkMode ? 'bg-indigo-400' : 'bg-indigo-500'" style="animation-delay: .15s"></span>
+                <span class="h-3 w-3 animate-bounce rounded-full" :class="isDarkMode ? 'bg-indigo-400' : 'bg-indigo-500'" style="animation-delay: .3s"></span>
+              </div>
+              <p class="text-sm" :class="isDarkMode ? 'text-slate-300' : 'text-slate-600'">Analyzing your watchlist with AI...</p>
+            </div>
+
+            <section v-if="!isLoading && hasResults" class="flex flex-col gap-10">
+              <div class="flex flex-wrap items-center gap-3 rounded-2xl border px-6 py-4" :class="isDarkMode ? 'border-slate-800 bg-slate-900/60' : 'border-slate-200 bg-white'">
+                <Brain class="h-5 w-5 text-indigo-400" />
+                <p class="text-sm" :class="isDarkMode ? 'text-slate-300' : 'text-slate-600'">{{ originalQuery }}</p>
+              </div>
+
+              <div v-if="filteredBookmarks.length > 0" class="space-y-6">
+                <div class="flex flex-wrap items-center justify-between gap-4">
+                  <h4 class="flex items-center gap-2 text-lg font-semibold">
+                    <Film class="h-5 w-5 text-indigo-400" />
+                    From your watchlist
+                  </h4>
+                  <span class="text-sm font-medium" :class="isDarkMode ? 'text-slate-400' : 'text-slate-600'">{{ filteredBookmarks.length }} matches</span>
+                </div>
+                <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                  <div
+                    v-for="movie in filteredBookmarks"
+                    :key="movie.id"
+                    class="group flex cursor-pointer flex-col overflow-hidden rounded-3xl border shadow transition hover:-translate-y-1 hover:shadow-xl"
+                    :class="isDarkMode ? 'border-slate-800 bg-slate-900/70 shadow-black/30' : 'border-slate-200 bg-white shadow-slate-200/70'"
+                    @click="navigateToMovie(movie)"
+                  >
+                    <div class="relative aspect-[2/3] overflow-hidden">
+                      <img
+                        v-if="movie.poster_path"
+                        :src="`https://image.tmdb.org/t/p/w500${movie.poster_path}`"
+                        :alt="movie.title"
+                        class="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                      />
+                      <div v-else class="flex h-full w-full items-center justify-center bg-slate-800/60">
+                        <Film class="h-10 w-10 text-slate-500" />
+                      </div>
+                      <div class="absolute inset-0 bg-gradient-to-t from-slate-950/80 via-slate-950/10 to-transparent opacity-0 transition group-hover:opacity-100">
+                        <div class="absolute bottom-4 left-4 flex items-center gap-2 text-sm font-semibold text-white">
+                          <Play class="h-4 w-4" />
+                          View details
+                        </div>
+                      </div>
+                    </div>
+                    <div class="flex flex-1 flex-col gap-2 px-5 py-4">
+                      <h5 class="text-base font-semibold leading-snug">{{ movie.title }}</h5>
+                      <p class="text-sm" :class="isDarkMode ? 'text-slate-400' : 'text-slate-500'">{{ movie.year }}</p>
+                      <p v-if="movie.match_reason" class="text-sm" :class="isDarkMode ? 'text-indigo-300' : 'text-indigo-600'">{{ movie.match_reason }}</p>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
 
-            <!-- Suggested Items -->
-            <div v-if="suggestedItems.length > 0" class="results-group">
-              <div class="results-header">
-                <h4 class="results-title">
-                  <Sparkles class="section-icon" />
-                  You Might Also Like
-                </h4>
-                <span class="results-count">{{ suggestedItems.length }} suggestions</span>
-              </div>
-              <div class="suggestions-list">
-                <div 
-                  v-for="(item, index) in suggestedItems" 
-                  :key="index"
-                  class="suggestion-item"
-                >
-                  <div class="suggestion-number">{{ index + 1 }}</div>
-                  <div class="suggestion-content">
-                    <h5 class="suggestion-title">{{ item.title }} <span class="suggestion-year">({{ item.year }})</span></h5>
-                    <p class="suggestion-reason">{{ item.reason }}</p>
+              <div v-if="suggestedItems.length > 0" class="space-y-6">
+                <div class="flex flex-wrap items-center justify-between gap-4">
+                  <h4 class="flex items-center gap-2 text-lg font-semibold">
+                    <Sparkles class="h-5 w-5 text-indigo-400" />
+                    You might also like
+                  </h4>
+                  <span class="text-sm font-medium" :class="isDarkMode ? 'text-slate-400' : 'text-slate-600'">{{ suggestedItems.length }} suggestions</span>
+                </div>
+                <div class="space-y-4">
+                  <div
+                    v-for="(item, index) in suggestedItems"
+                    :key="index"
+                    class="flex gap-4 rounded-2xl border px-5 py-4 shadow-sm"
+                    :class="isDarkMode ? 'border-slate-800 bg-slate-900/60' : 'border-slate-200 bg-white'"
+                  >
+                    <div class="flex h-10 w-10 items-center justify-center rounded-full text-sm font-semibold" :class="isDarkMode ? 'bg-indigo-500/20 text-indigo-200' : 'bg-indigo-100 text-indigo-600'">
+                      {{ index + 1 }}
+                    </div>
+                    <div class="space-y-1">
+                      <h5 class="text-base font-semibold">
+                        {{ item.title }}
+                        <span class="text-sm font-medium" :class="isDarkMode ? 'text-slate-400' : 'text-slate-500'">({{ item.year }})</span>
+                      </h5>
+                      <p class="text-sm leading-relaxed" :class="isDarkMode ? 'text-slate-300' : 'text-slate-600'">{{ item.reason }}</p>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
 
-            <!-- No Results Message -->
-            <div v-if="filteredBookmarks.length === 0 && suggestedItems.length === 0" class="no-results">
-              <AlertCircle class="no-results-icon" />
-              <p class="no-results-text">No matches found for your query. Try different keywords!</p>
-            </div>
-          </div>
-
-          <!-- Error State -->
-          <div v-if="errorMessage" class="error-state">
-            <AlertCircle class="error-icon" />
-            <p class="error-text">{{ errorMessage }}</p>
-            <button @click="errorMessage = ''" class="dismiss-error">Dismiss</button>
-          </div>
-
-          <!-- Info Box when no results yet -->
-          <div v-if="!isLoading && !hasResults && !errorMessage" class="info-box">
-            <div class="info-icon-wrapper">
-              <Sparkles class="info-sparkles" />
-            </div>
-            <h4 class="info-title">AI-Powered Watchlist Filter</h4>
-            <p class="info-description">
-              Describe the mood or type of content you're looking for, and our AI will intelligently filter your watchlist and suggest similar titles you might love.
-            </p>
-            <div class="info-features">
-              <div class="feature-item">
-                <span class="feature-bullet">✨</span>
-                <span>Natural language queries</span>
+              <div v-if="filteredBookmarks.length === 0 && suggestedItems.length === 0" class="flex flex-col items-center gap-3 rounded-2xl border px-8 py-12 text-center" :class="isDarkMode ? 'border-slate-800 bg-slate-900/60' : 'border-slate-200 bg-white'">
+                <AlertCircle class="h-6 w-6 text-amber-400" />
+                <p class="text-sm font-medium" :class="isDarkMode ? 'text-slate-300' : 'text-slate-600'">No matches found. Try different keywords or broaden your description.</p>
               </div>
-              <div class="feature-item">
-                <span class="feature-bullet">🎯</span>
-                <span>Smart filtering from your watchlist</span>
-              </div>
-              <div class="feature-item">
-                <span class="feature-bullet">🎬</span>
-                <span>Personalized recommendations</span>
+            </section>
+
+            <div
+              v-if="errorMessage"
+              class="flex items-start gap-3 rounded-2xl border px-6 py-4 text-sm"
+              :class="isDarkMode ? 'border-red-500/40 bg-red-500/10 text-red-200' : 'border-red-200 bg-red-50 text-red-700'"
+            >
+              <AlertCircle class="h-5 w-5" />
+              <div class="flex flex-1 flex-col gap-2">
+                <p>{{ errorMessage }}</p>
+                <button
+                  @click="errorMessage = ''"
+                  class="self-start rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide transition"
+                  :class="isDarkMode ? 'border-red-400/40 hover:bg-red-500/20' : 'border-red-200 hover:bg-red-100'"
+                >
+                  Dismiss
+                </button>
               </div>
             </div>
+
+            <section
+              v-if="!isLoading && !hasResults && !errorMessage"
+              class="grid gap-6 rounded-3xl border px-8 py-10 shadow-lg md:grid-cols-[minmax(0,1fr),minmax(0,1fr)]"
+              :class="isDarkMode ? 'border-slate-800 bg-slate-900/60 shadow-black/30' : 'border-slate-200 bg-white shadow-slate-200/60'"
+            >
+              <div class="space-y-4">
+                <h4 class="text-xl font-semibold">How the AI filter helps</h4>
+                <p class="text-sm leading-relaxed" :class="isDarkMode ? 'text-slate-300' : 'text-slate-600'">
+                  We translate your prompt into cinematic traits, compare them against your saved titles and surface extra recommendations that share the same vibe.
+                </p>
+                <ul class="space-y-3 text-sm" :class="isDarkMode ? 'text-slate-300' : 'text-slate-600'">
+                  <li class="flex items-start gap-2"><span class="mt-1 text-indigo-400">&bull;</span><span>Blend moods, genres or references&mdash;the model understands natural descriptions.</span></li>
+                  <li class="flex items-start gap-2"><span class="mt-1 text-indigo-400">&bull;</span><span>Quickly spotlight relevant items from your watchlist without manual scanning.</span></li>
+                  <li class="flex items-start gap-2"><span class="mt-1 text-indigo-400">&bull;</span><span>Get complementary picks to keep your queue fresh.</span></li>
+                </ul>
+              </div>
+              <div class="flex flex-col justify-center gap-4 rounded-2xl border px-6 py-6 text-sm" :class="isDarkMode ? 'border-slate-800 bg-slate-950/70' : 'border-slate-200 bg-slate-50'">
+                <h5 class="text-base font-semibold">Tips for great prompts</h5>
+                <ul class="space-y-3" :class="isDarkMode ? 'text-slate-300' : 'text-slate-600'">
+                  <li>
+                    <span class="font-medium text-indigo-400">Add context:</span> mention tone ("light-hearted"), pace ("slow-burn") or company ("for a family movie night").
+                  </li>
+                  <li>
+                    <span class="font-medium text-indigo-400">Reference favorites:</span> call out a title you love so the AI can mirror its feel.
+                  </li>
+                  <li>
+                    <span class="font-medium text-indigo-400">Set limits:</span> include runtime, release era or language preferences if needed.
+                  </li>
+                </ul>
+              </div>
+            </section>
           </div>
         </div>
       </div>
@@ -210,12 +272,11 @@
 
 <script setup>
 import { ref, computed } from 'vue';
-import { 
-  Sparkles, XIcon, Loader2, Brain, Film, Play, 
-  AlertCircle 
+import {
+  Sparkles, XIcon, Loader2, Brain, Film, Play,
+  AlertCircle
 } from 'lucide-vue-next';
 import axios from 'axios';
-import { useRouter } from 'vue-router';
 
 const props = defineProps({
   isDarkMode: {
@@ -225,8 +286,6 @@ const props = defineProps({
 });
 
 const emit = defineEmits(['filtered-results']);
-
-const router = useRouter();
 const config = useRuntimeConfig();
 
 // State
@@ -265,9 +324,9 @@ const closeAIFilter = () => {
 const getAccessToken = () => {
   if (process.client) {
     const cookie = document.cookie
-      .split("; ")
-      .find((row) => row.startsWith("access_token"));
-    return cookie ? cookie.split("=")[1] : null;
+      .split('; ')
+      .find((row) => row.startsWith('access_token'));
+    return cookie ? cookie.split('=')[1] : null;
   }
   return null;
 };
@@ -304,7 +363,7 @@ const submitQuery = async () => {
       originalQuery.value = response.data.query;
       filteredBookmarks.value = response.data.filtered || [];
       suggestedItems.value = response.data.suggestions || [];
-      
+
       // Emit filtered results to parent
       emit('filtered-results', {
         filtered: filteredBookmarks.value,
@@ -343,1121 +402,3 @@ const navigateToMovie = (movie) => {
   }
 };
 </script>
-
-<style scoped>
-/* CSS Variables - Dark Mode Only */
-.ai-filter-wrapper {
-  --ai-primary: #6366f1;
-  --ai-secondary: #4f46e5;
-  --ai-accent: #818cf8;
-  --ai-glow: rgba(99, 102, 241, 0.4);
-  
-  /* Dark Mode Colors */
-  --bg-primary: #0a0e1a;
-  --bg-secondary: #111827;
-  --bg-tertiary: #1f2937;
-  --bg-card: #1e293b;
-  --text-primary: #f8fafc;
-  --text-secondary: #cbd5e1;
-  --text-tertiary: #94a3b8;
-  --border-color: #334155;
-  --border-light: #1e293b;
-  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.5);
-  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.5);
-  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.5);
-  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.5);
-  --success: #10b981;
-  --error: #ef4444;
-}
-
-/* Trigger Button - Redesigned */
-.ai-filter-trigger {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  padding: 12px 24px;
-  background: linear-gradient(135deg, var(--ai-primary) 0%, var(--ai-secondary) 100%);
-  border: none;
-  border-radius: 14px;
-  color: #ffffff;
-  font-weight: 600;
-  font-size: 15px;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-  cursor: pointer;
-  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 4px 14px var(--ai-glow), 0 2px 4px rgba(0, 0, 0, 0.1);
-  overflow: hidden;
-}
-
-.ai-filter-trigger::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
-  transition: left 0.5s ease;
-}
-
-.ai-filter-trigger:hover::before {
-  left: 100%;
-}
-
-.ai-filter-trigger:hover {
-  transform: translateY(-2px) scale(1.02);
-  box-shadow: 0 8px 20px var(--ai-glow), 0 4px 8px rgba(0, 0, 0, 0.15);
-}
-
-.ai-filter-trigger:active {
-  transform: translateY(0) scale(0.98);
-}
-
-.ai-icon {
-  width: 20px;
-  height: 20px;
-  filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.5));
-  animation: sparkle 3s ease-in-out infinite;
-}
-
-@keyframes sparkle {
-  0%, 100% { 
-    transform: rotate(0deg) scale(1);
-    opacity: 1;
-  }
-  25% { 
-    transform: rotate(-15deg) scale(1.15);
-    opacity: 0.9;
-  }
-  50% { 
-    transform: rotate(0deg) scale(1);
-    opacity: 1;
-  }
-  75% { 
-    transform: rotate(15deg) scale(1.15);
-    opacity: 0.9;
-  }
-}
-
-/* Modal Container - Redesigned */
-.ai-modal-container {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-  width: 100vw;
-  background: var(--bg-primary);
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-}
-
-/* Modal Header - Redesigned */
-.ai-modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 28px 48px;
-  border-bottom: 2px solid var(--border-color);
-  background: linear-gradient(135deg, 
-    rgba(99, 102, 241, 0.08) 0%, 
-    rgba(79, 70, 229, 0.05) 50%,
-    var(--bg-primary) 100%);
-  backdrop-filter: blur(20px);
-  position: relative;
-}
-
-.ai-modal-header::after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: linear-gradient(90deg, 
-    transparent 0%, 
-    var(--ai-primary) 50%, 
-    transparent 100%);
-  opacity: 0.3;
-}
-
-.header-content {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-
-.header-icon-wrapper {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 64px;
-  height: 64px;
-  background: linear-gradient(135deg, var(--ai-primary) 0%, var(--ai-secondary) 100%);
-  border-radius: 18px;
-  box-shadow: 0 8px 32px var(--ai-glow), 0 4px 8px rgba(0, 0, 0, 0.1);
-  position: relative;
-}
-
-.header-icon-wrapper::before {
-  content: '';
-  position: absolute;
-  inset: -2px;
-  background: linear-gradient(135deg, var(--ai-primary), var(--ai-secondary));
-  border-radius: 20px;
-  opacity: 0.3;
-  filter: blur(8px);
-  z-index: -1;
-}
-
-.header-icon {
-  width: 28px;
-  height: 28px;
-  color: #ffffff;
-  filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.6));
-  animation: sparkle 3s ease-in-out infinite;
-}
-
-.ai-modal-title {
-  font-size: 28px;
-  font-weight: 700;
-  color: #f8fafc;
-  margin: 0;
-  letter-spacing: -0.5px;
-}
-
-.ai-modal-subtitle {
-  font-size: 15px;
-  color: #cbd5e1;
-  margin: 6px 0 0 0;
-  font-weight: 500;
-}
-
-.close-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 44px;
-  height: 44px;
-  border-radius: 12px;
-  background: var(--bg-tertiary);
-  border: 2px solid var(--border-color);
-  cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  backdrop-filter: blur(10px);
-}
-
-.close-btn:hover {
-  background: var(--ai-primary);
-  border-color: var(--ai-primary);
-  transform: rotate(90deg) scale(1.05);
-  box-shadow: 0 4px 16px var(--ai-glow);
-}
-
-.close-icon {
-  width: 22px;
-  height: 22px;
-  color: var(--text-secondary);
-  stroke-width: 2.5;
-  transition: color 0.3s ease;
-}
-
-.close-btn:hover .close-icon {
-  color: #ffffff;
-}
-
-/* Modal Body - Redesigned */
-.ai-modal-body {
-  flex: 1;
-  overflow-y: auto;
-  padding: 40px 48px;
-  background: #0f1623;
-  position: relative;
-}
-
-.ai-modal-body::-webkit-scrollbar {
-  width: 10px;
-}
-
-.ai-modal-body::-webkit-scrollbar-track {
-  background: var(--bg-primary);
-  border-radius: 10px;
-}
-
-.ai-modal-body::-webkit-scrollbar-thumb {
-  background: var(--border-color);
-  border-radius: 10px;
-  transition: background 0.3s ease;
-}
-
-.ai-modal-body::-webkit-scrollbar-thumb:hover {
-  background: var(--ai-primary);
-}
-
-/* Input Section - Redesigned */
-.input-section {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  margin-bottom: 32px;
-  padding: 32px;
-  background: #1a2332;
-  border-radius: 20px;
-  border: 2px solid #334155;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
-  position: relative;
-  overflow: hidden;
-}
-
-.input-section::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 4px;
-  background: linear-gradient(90deg, 
-    var(--ai-primary) 0%, 
-    var(--ai-secondary) 50%, 
-    var(--ai-accent) 100%);
-  opacity: 0.6;
-}
-
-.input-wrapper {
-  position: relative;
-}
-
-.ai-input {
-  width: 100%;
-  padding: 18px 20px;
-  border: 2px solid #475569;
-  border-radius: 14px;
-  background: #1e293b;
-  color: #f8fafc;
-  font-size: 16px;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-  line-height: 1.6;
-  resize: vertical;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  min-height: 140px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
-}
-
-.ai-input:focus {
-  outline: none;
-  border-color: var(--ai-primary);
-  box-shadow: 0 0 0 4px var(--ai-glow), 0 8px 16px rgba(0, 0, 0, 0.4);
-  background: #2d3748;
-}
-
-.ai-input:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  background: var(--bg-tertiary);
-}
-
-.ai-input::placeholder {
-  color: #cbd5e1;
-  font-weight: 400;
-  opacity: 0.7;
-}
-
-.input-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 8px;
-  padding: 0 4px;
-}
-
-.input-hint {
-  font-size: 13px;
-  color: #cbd5e1;
-  font-weight: 500;
-}
-
-.char-count {
-  font-size: 13px;
-  color: #cbd5e1;
-  font-weight: 600;
-  padding: 4px 10px;
-  background: #2d3748;
-  border-radius: 8px;
-  border: 1px solid #475569;
-}
-
-/* Quick Suggestions - Redesigned */
-.quick-suggestions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  align-items: center;
-}
-
-.suggestions-label {
-  font-size: 14px;
-  font-weight: 700;
-  color: #f8fafc;
-  margin-right: 4px;
-  letter-spacing: -0.2px;
-}
-
-.suggestion-chip {
-  padding: 10px 18px;
-  background: #2d3748;
-  border: 2px solid #475569;
-  border-radius: 24px;
-  color: #f8fafc;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  position: relative;
-  overflow: hidden;
-}
-
-.suggestion-chip::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(90deg, transparent, rgba(99, 102, 241, 0.1), transparent);
-  transition: left 0.5s ease;
-}
-
-.suggestion-chip:hover::before {
-  left: 100%;
-}
-
-.suggestion-chip:hover:not(:disabled) {
-  background: linear-gradient(135deg, var(--ai-primary), var(--ai-secondary));
-  color: #ffffff;
-  border-color: var(--ai-primary);
-  transform: translateY(-2px) scale(1.02);
-  box-shadow: 0 6px 16px var(--ai-glow);
-}
-
-.suggestion-chip:active:not(:disabled) {
-  transform: translateY(0) scale(0.98);
-}
-
-.suggestion-chip:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-  background: var(--bg-tertiary);
-}
-
-/* Submit Button - Redesigned */
-.submit-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  padding: 16px 40px;
-  background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%);
-  border: none;
-  border-radius: 14px;
-  color: #ffffff;
-  font-weight: 700;
-  font-size: 16px;
-  cursor: pointer;
-  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 8px 24px rgba(99, 102, 241, 0.5), 0 4px 8px rgba(0, 0, 0, 0.3);
-  position: relative;
-  overflow: hidden;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-}
-
-.submit-btn::before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 0;
-  height: 0;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.2);
-  transform: translate(-50%, -50%);
-  transition: width 0.6s, height 0.6s;
-}
-
-.submit-btn:hover::before {
-  width: 300px;
-  height: 300px;
-}
-
-.submit-btn:hover:not(:disabled) {
-  transform: translateY(-3px) scale(1.02);
-  box-shadow: 0 12px 40px rgba(99, 102, 241, 0.6), 0 6px 16px rgba(0, 0, 0, 0.4);
-  background: linear-gradient(135deg, #7c3aed 0%, #6366f1 100%);
-}
-
-.submit-btn:active:not(:disabled) {
-  transform: translateY(-1px) scale(0.98);
-}
-
-.submit-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  transform: none;
-  background: var(--bg-tertiary);
-  box-shadow: none;
-}
-
-.submit-icon,
-.loading-icon {
-  width: 20px;
-  height: 20px;
-  z-index: 1;
-}
-
-.loading-icon {
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-
-/* Loading State - Redesigned */
-.loading-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 64px 32px;
-  background: var(--bg-card);
-  border-radius: 20px;
-  border: 2px solid var(--border-color);
-  box-shadow: var(--shadow-lg);
-}
-
-.loading-animation {
-  display: flex;
-  gap: 14px;
-  margin-bottom: 28px;
-}
-
-.loading-circle {
-  width: 16px;
-  height: 16px;
-  background: linear-gradient(135deg, var(--ai-primary), var(--ai-secondary));
-  border-radius: 50%;
-  box-shadow: 0 4px 12px var(--ai-glow);
-  animation: bounce 1.4s ease-in-out infinite;
-}
-
-.loading-circle:nth-child(1) {
-  animation-delay: -0.32s;
-}
-
-.loading-circle:nth-child(2) {
-  animation-delay: -0.16s;
-}
-
-@keyframes bounce {
-  0%, 80%, 100% {
-    transform: scale(0) translateY(0);
-    opacity: 0.3;
-  }
-  40% {
-    transform: scale(1.2) translateY(-10px);
-    opacity: 1;
-  }
-}
-
-.loading-text {
-  font-size: 17px;
-  color: #f8fafc;
-  font-weight: 600;
-  letter-spacing: -0.3px;
-}
-
-/* Results Section */
-.results-section {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
-
-.query-display {
-  display: flex;
-  align-items: flex-start;
-  gap: 16px;
-  padding: 20px 24px;
-  background: var(--bg-card);
-  border: 2px solid var(--border-color);
-  border-radius: 16px;
-  border-left: 5px solid var(--ai-primary);
-  box-shadow: var(--shadow-md);
-  margin-bottom: 24px;
-}
-
-.query-icon {
-  width: 22px;
-  height: 22px;
-  color: var(--ai-primary);
-  flex-shrink: 0;
-  margin-top: 2px;
-  filter: drop-shadow(0 0 4px var(--ai-glow));
-}
-
-.query-text {
-  font-size: 15px;
-  color: #f8fafc;
-  font-style: italic;
-  font-weight: 500;
-  line-height: 1.6;
-  margin: 0;
-}
-
-/* Results Group - Redesigned */
-.results-group {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  margin-bottom: 32px;
-}
-
-.results-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding-bottom: 16px;
-  border-bottom: 3px solid var(--border-color);
-  position: relative;
-}
-
-.results-header::after {
-  content: '';
-  position: absolute;
-  bottom: -3px;
-  left: 0;
-  width: 80px;
-  height: 3px;
-  background: linear-gradient(90deg, var(--ai-primary), var(--ai-secondary));
-  border-radius: 3px;
-}
-
-.results-title {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  font-size: 22px;
-  font-weight: 700;
-  color: #f8fafc;
-  margin: 0;
-  letter-spacing: -0.5px;
-}
-
-.section-icon {
-  width: 24px;
-  height: 24px;
-  color: var(--ai-primary);
-  filter: drop-shadow(0 0 4px var(--ai-glow));
-}
-
-.results-count {
-  padding: 6px 16px;
-  background: linear-gradient(135deg, var(--ai-primary), var(--ai-secondary));
-  color: #ffffff;
-  border-radius: 24px;
-  font-size: 14px;
-  font-weight: 700;
-  box-shadow: 0 4px 12px var(--ai-glow);
-}
-
-/* Movies Grid - Redesigned */
-.movies-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  gap: 24px;
-}
-
-.movie-card {
-  cursor: pointer;
-  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-  border-radius: 16px;
-  overflow: hidden;
-}
-
-.movie-card:hover {
-  transform: translateY(-6px);
-}
-
-.movie-poster-wrapper {
-  position: relative;
-  aspect-ratio: 2/3;
-  border-radius: 16px;
-  overflow: hidden;
-  background: var(--bg-tertiary);
-  box-shadow: var(--shadow-lg);
-  border: 2px solid var(--border-color);
-  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.movie-card:hover .movie-poster-wrapper {
-  box-shadow: 0 12px 40px var(--shadow-medium), 0 0 0 3px var(--ai-primary);
-  border-color: var(--ai-primary);
-}
-
-.movie-poster {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.poster-placeholder {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--bg-tertiary);
-}
-
-.placeholder-icon {
-  width: 48px;
-  height: 48px;
-  color: var(--text-tertiary);
-}
-
-.movie-overlay {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, 
-    rgba(99, 102, 241, 0.9) 0%, 
-    rgba(79, 70, 229, 0.9) 100%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 0;
-  transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-  backdrop-filter: blur(4px);
-}
-
-.movie-card:hover .movie-overlay {
-  opacity: 1;
-}
-
-.play-icon {
-  width: 56px;
-  height: 56px;
-  color: #ffffff;
-  filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.3));
-  animation: pulse 2s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%, 100% { transform: scale(1); }
-  50% { transform: scale(1.1); }
-}
-
-.movie-info {
-  padding: 12px 0;
-}
-
-.movie-title {
-  font-size: 15px;
-  font-weight: 700;
-  color: #f8fafc;
-  margin: 0 0 6px 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
-  -webkit-box-orient: vertical;
-  line-height: 1.3;
-  letter-spacing: -0.2px;
-}
-
-.movie-year {
-  font-size: 13px;
-  color: #cbd5e1;
-  margin: 0 0 10px 0;
-  font-weight: 600;
-  background: #2d3748;
-  display: inline-block;
-  padding: 3px 10px;
-  border-radius: 8px;
-  border: 1px solid #475569;
-}
-
-.movie-reason {
-  font-size: 13px;
-  color: #cbd5e1;
-  line-height: 1.5;
-  margin: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
-  -webkit-box-orient: vertical;
-  font-weight: 500;
-}
-
-/* Suggestions List */
-.suggestions-list {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.suggestion-item {
-  display: flex;
-  gap: 16px;
-  padding: 20px;
-  background: var(--bg-tertiary);
-  border: 2px solid var(--border-color);
-  border-radius: 12px;
-  transition: all 0.2s ease;
-}
-
-.dark-mode .suggestion-item {
-  background: var(--bg-tertiary);
-}
-
-.suggestion-item:hover {
-  border-color: var(--ai-primary);
-  box-shadow: 0 4px 12px rgba(139, 92, 246, 0.2);
-  transform: translateY(-2px);
-}
-
-.suggestion-number {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  background: linear-gradient(135deg, var(--ai-primary), var(--ai-secondary));
-  color: white;
-  border-radius: 8px;
-  font-weight: 700;
-  font-size: 14px;
-  flex-shrink: 0;
-}
-
-.suggestion-content {
-  flex: 1;
-}
-
-.suggestion-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin: 0 0 8px 0;
-}
-
-.suggestion-year {
-  color: var(--text-tertiary);
-  font-weight: 400;
-}
-
-.suggestion-reason {
-  font-size: 13px;
-  color: var(--text-secondary);
-  line-height: 1.5;
-  margin: 0;
-}
-
-/* No Results */
-.no-results {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 48px 24px;
-  text-align: center;
-}
-
-.no-results-icon {
-  width: 48px;
-  height: 48px;
-  color: var(--text-tertiary);
-  margin-bottom: 16px;
-}
-
-.no-results-text {
-  font-size: 15px;
-  color: var(--text-secondary);
-  margin: 0;
-}
-
-/* Error State - Redesigned */
-.error-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 40px 32px;
-  text-align: center;
-  background: var(--bg-card);
-  border: 2px solid rgba(239, 68, 68, 0.3);
-  border-radius: 20px;
-  margin: 20px 0;
-  box-shadow: 0 8px 24px rgba(239, 68, 68, 0.15);
-  position: relative;
-  overflow: hidden;
-}
-
-.error-state::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 4px;
-  background: linear-gradient(90deg, #ef4444, #dc2626);
-}
-
-.error-icon {
-  width: 56px;
-  height: 56px;
-  color: #ef4444;
-  margin-bottom: 20px;
-  filter: drop-shadow(0 4px 12px rgba(239, 68, 68, 0.3));
-  animation: shake 0.5s ease-in-out;
-}
-
-@keyframes shake {
-  0%, 100% { transform: translateX(0); }
-  25% { transform: translateX(-10px); }
-  75% { transform: translateX(10px); }
-}
-
-.error-text {
-  font-size: 16px;
-  color: #f8fafc;
-  line-height: 1.7;
-  margin: 0 0 24px 0;
-  max-width: 600px;
-  font-weight: 500;
-}
-
-.dismiss-error {
-  padding: 12px 28px;
-  background: var(--bg-primary);
-  border: 2px solid var(--border-color);
-  border-radius: 12px;
-  color: #f8fafc;
-  font-size: 15px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: var(--shadow-sm);
-}
-
-.dismiss-error:hover {
-  background: var(--ai-primary);
-  color: #ffffff;
-  border-color: var(--ai-primary);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 16px var(--ai-glow);
-}
-
-/* Info Box - Redesigned */
-.info-box {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 56px 48px;
-  background: #1a2332;
-  border: 2px solid #334155;
-  border-radius: 24px;
-  text-align: center;
-  margin: 20px 0;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
-  position: relative;
-  overflow: hidden;
-}
-
-.info-box::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 4px;
-  background: linear-gradient(90deg, 
-    var(--ai-primary) 0%, 
-    var(--ai-secondary) 50%, 
-    var(--ai-accent) 100%);
-}
-
-.info-icon-wrapper {
-  width: 96px;
-  height: 96px;
-  background: linear-gradient(135deg, var(--ai-primary) 0%, var(--ai-secondary) 100%);
-  border-radius: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 28px;
-  box-shadow: 0 12px 40px var(--ai-glow), 0 4px 12px rgba(0, 0, 0, 0.1);
-  position: relative;
-}
-
-.info-icon-wrapper::before {
-  content: '';
-  position: absolute;
-  inset: -3px;
-  background: linear-gradient(135deg, var(--ai-primary), var(--ai-secondary));
-  border-radius: 27px;
-  opacity: 0.3;
-  filter: blur(12px);
-  z-index: -1;
-}
-
-.info-sparkles {
-  width: 40px;
-  height: 40px;
-  color: #ffffff;
-  filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.6));
-  animation: sparkle 3s ease-in-out infinite;
-}
-
-.info-title {
-  font-size: 28px;
-  font-weight: 700;
-  color: #f8fafc;
-  margin: 0 0 16px 0;
-  letter-spacing: -0.5px;
-}
-
-.info-description {
-  font-size: 17px;
-  line-height: 1.7;
-  color: #cbd5e1;
-  margin: 0 0 40px 0;
-  max-width: 650px;
-  font-weight: 500;
-}
-
-.info-features {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  align-items: flex-start;
-  background: #0f1623;
-  padding: 24px 32px;
-  border-radius: 16px;
-  border: 2px solid #475569;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-}
-
-.feature-item {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  font-size: 16px;
-  color: #f8fafc;
-  font-weight: 500;
-}
-
-.feature-bullet {
-  font-size: 22px;
-  flex-shrink: 0;
-  line-height: 1;
-}
-
-/* Responsive Design - Redesigned */
-@media (max-width: 768px) {
-  .ai-modal-header {
-    padding: 20px 24px;
-  }
-
-  .header-icon-wrapper {
-    width: 48px;
-    height: 48px;
-  }
-
-  .header-icon {
-    width: 22px;
-    height: 22px;
-  }
-
-  .ai-modal-title {
-    font-size: 22px;
-  }
-
-  .ai-modal-subtitle {
-    font-size: 13px;
-  }
-
-  .ai-modal-body {
-    padding: 24px 20px;
-  }
-
-  .input-section {
-    padding: 24px 20px;
-  }
-
-  .ai-input {
-    font-size: 15px;
-    min-height: 120px;
-  }
-
-  .submit-btn {
-    padding: 14px 32px;
-    font-size: 15px;
-  }
-
-  .movies-grid {
-    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-    gap: 16px;
-  }
-
-  .suggestion-item {
-    flex-direction: column;
-    gap: 12px;
-  }
-
-  .info-box {
-    padding: 32px 24px;
-  }
-
-  .info-features {
-    width: 100%;
-    padding: 20px 24px;
-  }
-
-  .results-title {
-    font-size: 18px;
-  }
-
-  .close-btn {
-    width: 40px;
-    height: 40px;
-  }
-}
-
-@media (max-width: 480px) {
-  .ai-filter-trigger {
-    padding: 10px 18px;
-    font-size: 14px;
-  }
-
-  .ai-modal-header {
-    padding: 16px;
-  }
-
-  .ai-modal-title {
-    font-size: 20px;
-  }
-
-  .suggestion-chip {
-    font-size: 13px;
-    padding: 8px 14px;
-  }
-
-  .movies-grid {
-    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
-    gap: 12px;
-  }
-}
-</style>


### PR DESCRIPTION
## Summary
- rebuild the AI watchlist filter modal with Tailwind utility classes and a gradient trigger button that adapts to light and dark themes
- replace the previous info panel with clearer onboarding content and prompt tips that explain how the AI filtering works
- refresh result, suggestion, loading, and error states with responsive Tailwind layouts for easier scanning

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e06a011dd0832897fc1c426033fd6c